### PR TITLE
Comparison logger

### DIFF
--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -9,6 +9,9 @@ def make_argument_parser():
     ap.add_argument("-v", "--verbose",
                     help="increase output verbosity",
                     action="count", default=0)
+    ap.add_argument("-d", "--debug",
+                    help="increase debug output verbosity",
+                    action="count", default=0)
     sub_ap = ap.add_subparsers(dest="command", metavar="command")
     sub_ap.required = True
 

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -26,6 +26,8 @@ def run_from_cli():
     """Main method to run the tool."""
     ap = make_argument_parser()
     args = ap.parse_args()
+    if args.verbose or args.debug:
+        args.verbose = 1 + args.debug
     args.func(args)
 
 

--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -163,7 +163,7 @@ void DebugInfo::extractAlignmentFromInstructions(GetElementPtrInst *GEP,
                                                IndexConstant->getBitWidth(),
                                                ModFirst.getContext());
                         DEBUG_WITH_TYPE(
-                                DEBUG_SIMPLL_VERBOSE,
+                                DEBUG_SIMPLL_VERBOSE_EXTRA,
                                 dbgs() << "Index alignment in:" << *GEP << "\n"
                                        << "                     " << indexFirst
                                        << " -> " << indexSecond << "\n");

--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "DebugInfo.h"
+#include "Logger.h"
 #include <llvm/ADT/StringExtras.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/InstIterator.h>
@@ -162,11 +163,11 @@ void DebugInfo::extractAlignmentFromInstructions(GetElementPtrInst *GEP,
                                                (unsigned)indexSecond,
                                                IndexConstant->getBitWidth(),
                                                ModFirst.getContext());
-                        DEBUG_WITH_TYPE(
-                                DEBUG_SIMPLL_VERBOSE_EXTRA,
-                                dbgs() << "Index alignment in:" << *GEP << "\n"
-                                       << "                     " << indexFirst
-                                       << " -> " << indexSecond << "\n");
+                        LOG_VERBOSE_EXTRA_NO_INDENT("Index alignment in:"
+                                                    << *GEP << "\n"
+                                                    << "                     "
+                                                    << indexFirst << " -> "
+                                                    << indexSecond << "\n");
                     }
                     // Insert the names of the indices into StructFieldNames.
                     StructFieldNames.insert(

--- a/diffkemp/simpll/DebugInfo.h
+++ b/diffkemp/simpll/DebugInfo.h
@@ -16,6 +16,7 @@
 #define DIFFKEMP_SIMPLL_DEBUGINFO_H
 
 #include "Config.h"
+#include "Logger.h"
 #include "Utils.h"
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/Instructions.h>
@@ -48,9 +49,8 @@ class DebugInfo {
             : FunFirst(funFirst), FunSecond(funSecond), ModFirst(modFirst),
               ModSecond(modSecond), CalledFirst(CalledFirst),
               CalledSecond(CalledSecond) {
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                        dbgs() << "Analysing debugging information...\n";
-                        increaseDebugIndentLevel());
+        LOG_NO_INDENT("Analysing debugging information...\n");
+        LOG_INDENT();
         DebugInfoFirst.processModule(ModFirst);
         DebugInfoSecond.processModule(ModSecond);
         // Use debug info to gather useful information
@@ -58,7 +58,7 @@ class DebugInfo {
         calculateMacroAlignments();
         collectLocalVariables(CalledFirst, LocalVariableMapL);
         collectLocalVariables(CalledSecond, LocalVariableMapR);
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
+        LOG_UNINDENT();
     };
 
     /// Maps structure type and index to struct member names

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -422,9 +422,7 @@ void DifferentialFunctionComparator::findMacroFunctionDifference(
             ModComparator->tryInline = {nullptr, dyn_cast<CallInst>(R)};
         }
 
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                        dbgs() << getDebugIndent() << "Writing function-macro "
-                               << "syntactic difference\n");
+        LOG("Writing function-macro syntactic difference\n");
 
         std::unique_ptr<SyntaxDifference> diff =
                 std::make_unique<SyntaxDifference>();
@@ -758,10 +756,8 @@ bool DifferentialFunctionComparator::cmpCallArgumentUsingCSource(
     if ((CArgsL.size() > i) && (CArgsR.size() > i)) {
         if (mayIgnoreMacro(CArgsL[i]) && mayIgnoreMacro(CArgsR[i])
             && (CArgsL[i] == CArgsR[i])) {
-            DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                            dbgs() << getDebugIndent()
-                                   << "Comparing integers as equal because of "
-                                   << "correspondence to an ignored macro\n");
+            LOG("Comparing integers as equal because of "
+                << "correspondence to an ignored macro\n");
             return 0;
         }
 
@@ -778,11 +774,8 @@ bool DifferentialFunctionComparator::cmpCallArgumentUsingCSource(
             if (SizeL != ModComparator->StructSizeMapL.end()
                 && SizeR != ModComparator->StructSizeMapR.end()
                 && SizeL->second == SizeR->second) {
-                DEBUG_WITH_TYPE(
-                        DEBUG_SIMPLL,
-                        dbgs() << getDebugIndent()
-                               << "Comparing integers as equal because of"
-                               << "correspondence to structure type sizes\n");
+                LOG("Comparing integers as equal because of "
+                    << "correspondence to structure type sizes\n");
                 return 0;
             }
 
@@ -799,11 +792,8 @@ bool DifferentialFunctionComparator::cmpCallArgumentUsingCSource(
 
             if (DITypeL && DITypeR
                 && DITypeL->getName() == DITypeR->getName()) {
-                DEBUG_WITH_TYPE(
-                        DEBUG_SIMPLL,
-                        dbgs() << getDebugIndent()
-                               << "Comparing integers as equal because of"
-                               << "correspondence of structure names\n");
+                LOG("Comparing integers as equal because of "
+                    << "correspondence of structure names\n");
                 return 0;
             }
         }
@@ -913,9 +903,7 @@ int DifferentialFunctionComparator::cmpBasicBlocks(
                 // If there is an inequality found and we have previously found
                 // a possibly relocated block, try to match it now.
                 Reloc.status = RelocationInfo::Matching;
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << getDebugIndent()
-                                       << "Try to match the relocated block\n");
+                LOG("Try to match the relocated block\n");
                 // The instructions are not equal
                 undoLastInstCompare(InstL, InstR);
                 // Move instruction in the module that contains the relocated
@@ -976,18 +964,14 @@ int DifferentialFunctionComparator::cmpBasicBlocks(
                 // If the relocated code has been entirely matched, we can
                 // continue from the restore point.
                 if (Reloc.prog == Program::First && InstL == Reloc.end) {
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                    dbgs() << getDebugIndent()
-                                           << "Relocated block matched\n");
+                    LOG("Relocated block matched\n");
                     InstL = Reloc.restore;
                     InstR++;
                     Reloc.status = RelocationInfo::None;
                     continue;
                 } else if (Reloc.prog == Program::Second
                            && InstR == Reloc.end) {
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                    dbgs() << getDebugIndent()
-                                           << "Relocated block matched\n");
+                    LOG("Relocated block matched\n");
                     InstL++;
                     InstR = Reloc.restore;
                     Reloc.status = RelocationInfo::None;
@@ -1771,11 +1755,9 @@ bool DifferentialFunctionComparator::findMatchingOpWithOffset(
             if (isDependingOnReloc(*MovedInst))
                 return false;
 
-            DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                            dbgs() << getDebugIndent()
-                                   << "Possible relocation found:\n"
-                                   << "    from: " << *Reloc.begin << "\n"
-                                   << "      to: " << *Reloc.end << "\n");
+            LOG("Possible relocation found:\n"
+                << "    from: " << *Reloc.begin << "\n"
+                << "      to: " << *Reloc.end << "\n");
             return true;
         }
         // Restore serial maps since the instructions do not match

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -18,6 +18,7 @@
 
 #include "DebugInfo.h"
 #include "FunctionComparator.h"
+#include "Logger.h"
 #include "ModuleComparator.h"
 #include "PatternComparator.h"
 #include "Utils.h"
@@ -132,6 +133,7 @@ class DifferentialFunctionComparator : public FunctionComparator {
     const DataLayout &LayoutL, &LayoutR;
 
     mutable const DebugLoc *CurrentLocL, *CurrentLocR;
+    mutable Logger logger;
     mutable std::set<std::pair<const Value *, const Value *>> inverseConditions;
     mutable std::vector<std::pair<const PHINode *, const PHINode *>>
             phisToCompare;

--- a/diffkemp/simpll/Logger.cpp
+++ b/diffkemp/simpll/Logger.cpp
@@ -1,0 +1,97 @@
+//===--------------- Logger.cpp - Logging debug information ---------------===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Kucma, xkucma00@vutbr.cz
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains functions used to log debug information.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Logger.h"
+#include "Utils.h"
+#include <llvm/Support/Debug.h>
+
+Logger logger{};
+
+llvm::raw_null_ostream Logger::null_stream{};
+
+void Logger::prepLog(const char *label,
+                     const BufferMessage::Value left,
+                     const BufferMessage::Value right) {
+    buffer.emplace_back(BufferMessage{level, label, left, right});
+}
+
+void Logger::prepContext() { level++; }
+
+void Logger::log(bool keep, const char *force_keep_type) {
+    bool force_keep = force_keep_type != nullptr
+                      && ::llvm::isCurrentDebugType(force_keep_type);
+    level--;
+    if (force_keep) {
+        for (auto iter = buffer.rbegin(); iter != buffer.rend(); iter++) {
+            if (level == iter->level) { // mark the message as force-kept
+                iter->force_kept = true;
+                break;
+            }
+            if (!keep && !iter->force_kept) { // erase non-force-kept children
+                iter->label = nullptr;
+                iter->force_kept = true;
+            }
+        }
+    }
+    keep = keep || force_keep;
+    if (level == 0) {
+        if (keep) {
+            dump();
+        }
+        buffer.clear();
+    } else if (!keep) {
+        while (!buffer.empty() && buffer.back().level > level) {
+            buffer.pop_back();
+        }
+        if (!buffer.empty()) {
+            buffer.pop_back();
+        }
+    }
+}
+
+void Logger::dump() {
+    // assuming level == 0
+    for (const auto &log : buffer) {
+        if (log.label == nullptr) {
+            continue;
+        }
+        setIndent(log.level);
+        LOG("L " << log.label << ": " << log.left << "\n");
+        LOG("R " << log.label << ": " << log.right << "\n");
+    }
+    setIndent(0);
+}
+
+void Logger::setIndent(size_t target_level) {
+    while (level < target_level) {
+        level += 1;
+        ::increaseDebugIndentLevel();
+    }
+    while (level > target_level) {
+        level -= 1;
+        ::decreaseDebugIndentLevel();
+    }
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &out,
+                              Logger::BufferMessage::Value value) {
+    switch (value.message_type) {
+    case value.llvmType:
+        out << *(value.type);
+        break;
+    case value.llvmValue:
+        out << *(value.value);
+        break;
+    }
+    return out;
+}

--- a/diffkemp/simpll/Logger.h
+++ b/diffkemp/simpll/Logger.h
@@ -1,0 +1,236 @@
+//===---------------- Logger.h - Logging debug information ----------------===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Kucma, xkucma00@vutbr.cz
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the Logger class that provides
+/// debug logging functions.
+///
+//===----------------------------------------------------------------------===//
+
+/**
+ * Usage:
+ *
+ * The standard use case of this logger is using LOG(message) macro to log
+ * messages to the debug output, which happens only if the debug output is
+ * enabled (DEBUG_SIMPLL flag). Multiple strings or printable objects can be
+ * chained within single LOG using operator '<<', for example:
+ *
+ *  LOG("Value: " << LeftValue << "\n").
+ *
+ * Each LOG automatically adds indentation to the beginning of the message,
+ * determined by the current indentation level, which can be manipulated by
+ * the macros LOG_INDENT() and LOG_UNINDENT(). This allows to log messages in
+ * a hierarchical manner. To log messages without indentation (e.g. when adding
+ * a single '\n' to the end of an already printed line), add suffix _NO_INDENT
+ * to the LOG macro.
+ *
+ * LOG_VERBOSE and LOG_VERBOSE_EXTRA (and their _NO_INDENT variants) behave
+ * analogically to LOG, but require setting a higher level of debug to print
+ * their messages (DEBUG_SIMPLL_VERBOSE and DEBUG_SIMPLL_VERBOSE_EXTRA,
+ * respectively; for their meaning and usage, see 'Debug levels' below).
+ *
+ *
+ * Logging hierarchical comparisons in 'DifferentialFunctionComparator.cpp'
+ * requires a special behavior for two reasons. By default, it's desirable to
+ * only log the comparisons where a difference was found in it and all its
+ * predecessors. Thus, logging needs to be done conditionally, based on the
+ * result of the comparison. Additionally, when a comparison is finished, the
+ * results of its predecessors are not yet known, and so the log of the
+ * comparison must be stored until its predecessors are resolved.
+ *
+ * Comparison log is first prepared using macro PREP_LOG(label, left, right) at
+ * the beginning of the comparison function, where 'label' is a string
+ * describing the compared objects and 'left'/'right' are pointers to the
+ * compared objects. This macro stores a representation of the comparison
+ * message in a buffer and prepares the context for logging its children.
+ * Example of usage:
+ *
+ *  PREP_LOG("value", L, R);
+ *
+ * Then, instead of calling return, RETURN_WITH_LOG(return_value) is used,
+ * ending the context. The result of the comparison is used to determine whether
+ * to keep the message and all its children, alternatively erasing them in the
+ * case no difference was found. Example of usage:
+ *
+ *  if (int Res = cmpValues(CL->getArgOperand(i), CR->getArgOperand(i)))
+ *      RETURN_WITH_LOG(Res);
+ *
+ * At the higher levels of debug, all comparisons are stored, regardless of the
+ * result. For the cases where this isn't desired, a variant of this macro
+ * RETURN_WITH_LOG_NEQ(return_value) can be used, ensuring keeping the message
+ * only if a difference was found in it and all its predecessors, regardless of
+ * the currently configured debug level.
+ *
+ * If RETURN_WITH_LOG (or its _NEQ variant) executed in the lowest level
+ * comparison leads to keeping the logged message, it and all its stored
+ * children comparison logs will be additionally automatically printed to the
+ * debug output. Base indentation for each line is determined by the current
+ * indentation level. Additional indentation is added to the individual messages
+ * based on their heirarchy.
+ *
+ *
+ * Debug levels (in ascending order):
+ *  - DEBUG_SIMPLL logs:
+ *      - module preprocessing
+ *      - function comparisons
+ *      - passes
+ *      - relocations
+ *      - pattern sets and pattern comparisons
+ *      - LLVM debug information analysis
+ * - DEBUG_SIMPLL_VERBOSE additionally logs:
+ *      - comparisons where a difference was found
+ * - DEBUG_SIMPLL_VERBOSE_EXTRA additionally logs:
+ *      - comparisons where no difference was found (unless _NEQ was used)
+ *      - macro processing
+ *      - details about index alignment in debug information analysis
+ *      - details about replacements in passes
+ *      - details about dependency slicing pass
+ */
+
+#ifndef DIFFKEMP_SIMPLL_LOGGER_H
+#define DIFFKEMP_SIMPLL_LOGGER_H
+
+#include <Config.h>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/Value.h>
+#include <llvm/Support/Debug.h>
+#include <llvm/Support/raw_ostream.h>
+#include <vector>
+
+#define LOGGER_BASE_LEVEL DEBUG_SIMPLL_VERBOSE
+#define LOGGER_FORCE_LEVEL DEBUG_SIMPLL_VERBOSE_EXTRA
+
+// Prepare a log message for (potential) future logging and create context for
+// logging its children. Must be later followed by LOG_KEEP or RETURN_WITH_LOG
+// (or the _FORCE/_NEQ variant, respectively), determining whether to keep
+// the message and marking the end of the context (see below for difference
+// between the variants).
+// Called once per each comparison level.
+#define PREP_LOG(label, left, right)                                           \
+    DEBUG_WITH_TYPE(LOGGER_BASE_LEVEL, logger.prepLog(label, left, right);     \
+                    logger.prepContext();)
+
+// Based on the given value (interpreted as bool), either keep or erase the
+// prepared message and its children. Additionally, if the prepared message
+// is kept and has no parent (meaning it's the lowest level message), print and
+// remove all stored messages, clearing the buffer.
+#define LOG_KEEP(keep) DEBUG_WITH_TYPE(LOGGER_BASE_LEVEL, logger.log(keep))
+
+// Force variant of LOG_KEEP.
+// If LOGGER_FORCE_LEVEL is not enabled, behaves identically to LOG_KEEP.
+// If it is enabled, forces keeping the message regardless of the given value
+// and marks that message as force-kept. However, its children that weren't
+// previously marked as force-kept will still be erased if the given value is
+// evaluated to false.
+#define LOG_KEEP_FORCE(keep)                                                   \
+    DEBUG_WITH_TYPE(LOGGER_BASE_LEVEL, logger.log(keep, LOGGER_FORCE_LEVEL))
+
+// Return and in case the return value is zero, i.e. no difference was found
+// in the current cmp* function, erase the prepared log message and its
+// children, ensuring only comparisons with difference are logged.
+// If LOGGER_FORCE_LEVEL is enabled, keeps the message regardless of the given
+// value and marks that message as force-kept. However, if the return value is
+// zero, non-force-kept children of a force-kept message are still erased.
+// Used for comparisons where it is desirable to log that a comparison has
+// occured even if no difference was found (when using higher level of debug
+// verbosity).
+#define RETURN_WITH_LOG(return_value)                                          \
+    do {                                                                       \
+        const auto &x = return_value;                                          \
+        LOG_KEEP_FORCE(x);                                                     \
+        return x;                                                              \
+    } while (false)
+
+// Variant of RETURN_WITH_LOG that only logs the comparisons where a difference
+// was found, regardless of the configured debug level. Messages logged using
+// this macro are never marked as force-kept.
+// Used for less important comparisons.
+#define RETURN_WITH_LOG_NEQ(return_value)                                      \
+    do {                                                                       \
+        const auto &x = return_value;                                          \
+        LOG_KEEP(x);                                                           \
+        return x;                                                              \
+    } while (false)
+
+#define LOG_NO_INDENT(msg) DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << msg)
+#define LOG_VERBOSE_NO_INDENT(msg)                                             \
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, dbgs() << msg)
+#define LOG_VERBOSE_EXTRA_NO_INDENT(msg)                                       \
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA, dbgs() << msg)
+
+#define LOG(msg) LOG_NO_INDENT(getDebugIndent() << msg)
+#define LOG_VERBOSE(msg) LOG_VERBOSE_NO_INDENT(getDebugIndent() << msg)
+#define LOG_VERBOSE_EXTRA(msg)                                                 \
+    LOG_VERBOSE_EXTRA_NO_INDENT(getDebugIndent() << msg)
+
+#define LOG_INDENT() DEBUG_WITH_TYPE(DEBUG_SIMPLL, increaseDebugIndentLevel())
+#define LOG_UNINDENT() DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel())
+
+class Logger {
+  public:
+    struct BufferMessage {
+        struct Value {
+            enum {
+                llvmValue,
+                llvmType,
+            } message_type;
+            union {
+                const llvm::Value *value;
+                const llvm::Type *type;
+            };
+            Value(const llvm::Value *value)
+                    : message_type{llvmValue}, value{value} {};
+            Value(const llvm::Type *type)
+                    : message_type{llvmType}, type{type} {};
+        };
+        bool force_kept{false};
+        size_t level;
+        const char *label;
+        const Value left;
+        const Value right;
+        BufferMessage(size_t level,
+                      const char *label,
+                      const Value left,
+                      const Value right)
+                : level{level}, label{label}, left{left}, right{right} {};
+    };
+    Logger(){};
+    // prepare message for logging
+    void prepLog(const char *label,
+                 const class BufferMessage::Value left,
+                 const class BufferMessage::Value right);
+    // prepare for logging messages within the context of the last prepared
+    // message
+    void prepContext();
+    // log a prepared message
+    void log(bool keep = true, const char *force_keep_type = nullptr);
+    // dump all messages from the buffer
+    void dump();
+
+  protected:
+    // set the logger indentation level to the given value, while modifying the
+    // real debug indentation as well
+    void setIndent(size_t target_level);
+
+  private:
+    // current level of indentation within the logger
+    size_t level{0};
+    // debug message buffer (force-kept, indent level, message)
+    std::vector<BufferMessage> buffer{};
+    // stream used to append to messages in buffer
+    std::unique_ptr<llvm::raw_ostream> stream{};
+    // null stream used for unwanted messages
+    static llvm::raw_null_ostream null_stream;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &out,
+                              Logger::BufferMessage::Value value);
+
+extern Logger logger;
+
+#endif // DIFFKEMP_SIMPLL_LOGGER_H

--- a/diffkemp/simpll/PatternComparator.cpp
+++ b/diffkemp/simpll/PatternComparator.cpp
@@ -17,6 +17,7 @@
 #include "PatternComparator.h"
 #include "Config.h"
 #include "DifferentialFunctionComparator.h"
+#include "Logger.h"
 #include "Utils.h"
 
 /// Tries to match a difference pattern starting with the given instruction
@@ -47,10 +48,8 @@ bool PatternComparator::matchValues(const Value *L, const Value *R) {
                 continue;
             }
 
-            DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                            dbgs() << getDebugIndent()
-                                   << "Found a match for value pattern "
-                                   << ValuePatternCompPair.first->Name << "\n");
+            LOG("Found a match for value pattern "
+                << ValuePatternCompPair.first->Name << "\n");
             return true;
         }
     }
@@ -79,10 +78,8 @@ bool PatternComparator::matchInstPattern(const Instruction *InstL,
                 continue;
             }
 
-            DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                            dbgs() << getDebugIndent()
-                                   << "Found a match for instruction pattern "
-                                   << InstPatternCompPair.first->Name << "\n");
+            LOG("Found a match for instruction pattern "
+                << InstPatternCompPair.first->Name << "\n");
 
             // Create a new instruction mapping since the match is valid.
             InstMappings.clear();

--- a/diffkemp/simpll/passes/ControlFlowSlicer.cpp
+++ b/diffkemp/simpll/passes/ControlFlowSlicer.cpp
@@ -15,6 +15,7 @@
 
 #include "ControlFlowSlicer.h"
 #include "Config.h"
+#include "Logger.h"
 #include "Utils.h"
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
@@ -85,9 +86,8 @@ bool isResultOnlyStored(const Instruction *Inst) {
 /// parameters, and all instructions depending on these.
 PreservedAnalyses ControlFlowSlicer::run(Function &Fun,
                                          FunctionAnalysisManager & /*fam*/) {
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                    dbgs() << "Slicing control-flow-only statements...\n";
-                    increaseDebugIndentLevel());
+    LOG_NO_INDENT("Slicing control-flow-only statements...\n");
+    LOG_INDENT();
     std::set<const Instruction *> Dependent;
     for (const auto &BB : Fun) {
         for (const auto &Instr : BB) {
@@ -141,15 +141,14 @@ PreservedAnalyses ControlFlowSlicer::run(Function &Fun,
     }
 
     if (!ToRemove.empty()) {
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
-                        dbgs() << "Removed instructions from " << Fun.getName()
-                               << ": \n");
+        LOG_VERBOSE_EXTRA_NO_INDENT("Removed instructions from "
+                                    << Fun.getName() << ": \n");
     }
 
     for (auto &Instr : ToRemove) {
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << *Instr << "\n";);
+        LOG_NO_INDENT(*Instr << "\n");
         Instr->eraseFromParent();
     }
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
+    LOG_UNINDENT();
     return PreservedAnalyses::none();
 }

--- a/diffkemp/simpll/passes/ControlFlowSlicer.cpp
+++ b/diffkemp/simpll/passes/ControlFlowSlicer.cpp
@@ -141,7 +141,7 @@ PreservedAnalyses ControlFlowSlicer::run(Function &Fun,
     }
 
     if (!ToRemove.empty()) {
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                         dbgs() << "Removed instructions from " << Fun.getName()
                                << ": \n");
     }

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
@@ -14,6 +14,7 @@
 
 #include "FunctionAbstractionsGenerator.h"
 #include "CalledFunctionsAnalysis.h"
+#include "Logger.h"
 #include "Utils.h"
 #include <Config.h>
 #include <llvm/ADT/Hashing.h>
@@ -26,10 +27,9 @@ AnalysisKey FunctionAbstractionsGenerator::Key;
 /// and for each pair of assembly code and constraint.
 FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
         Module &Mod, AnalysisManager<Module, Function *> &mam, Function *Main) {
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                    dbgs() << "Generating function abstractions in "
-                           << Mod.getName() << "...\n";
-                    increaseDebugIndentLevel());
+    LOG_NO_INDENT("Generating function abstractions in " << Mod.getName()
+                                                         << "...\n");
+    LOG_INDENT();
     FunMap funAbstractions;
     int i = 0;
     std::vector<Instruction *> toErase;
@@ -104,10 +104,9 @@ FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
                     auto newCall =
                             CallInst::Create(newFun, args, "", CallInstr);
                     newCall->setDebugLoc(CallInstr->getDebugLoc());
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
-                                    dbgs() << "Replacing :" << *CallInstr
-                                           << "\n     with :" << *newCall
-                                           << "\n");
+                    LOG_VERBOSE_EXTRA_NO_INDENT("Replacing :"
+                                                << *CallInstr << "\n     with :"
+                                                << *newCall << "\n");
                     CallInstr->replaceAllUsesWith(newCall);
                     toErase.push_back(&Instr);
                 }
@@ -117,7 +116,7 @@ FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
             toErase.clear();
         }
     }
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
+    LOG_UNINDENT();
     return FunctionAbstractionsGenerator::Result{funAbstractions};
 }
 

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
@@ -104,7 +104,7 @@ FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
                     auto newCall =
                             CallInst::Create(newFun, args, "", CallInstr);
                     newCall->setDebugLoc(CallInstr->getDebugLoc());
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
+                    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                                     dbgs() << "Replacing :" << *CallInstr
                                            << "\n     with :" << *newCall
                                            << "\n");

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -14,6 +14,7 @@
 #include "RemoveUnusedReturnValuesPass.h"
 #include "CalledFunctionsAnalysis.h"
 #include "FunctionAbstractionsGenerator.h"
+#include "Logger.h"
 #include "Utils.h"
 #include <Config.h>
 #include <llvm/IR/Instructions.h>
@@ -25,10 +26,9 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
         AnalysisManager<Module, Function *> &mam,
         Function *Main,
         Module *ModOther) {
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                    dbgs() << "Removing unused return values in "
-                           << Mod.getName() << "...\n";
-                    increaseDebugIndentLevel());
+    LOG_NO_INDENT("Removing unused return values in " << Mod.getName()
+                                                      << "...\n");
+    LOG_INDENT();
 
     auto &CalledFuns = mam.getResult<CalledFunctionsAnalysis>(Mod, Main);
 
@@ -74,10 +74,8 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
             // Nothing to replace.
             continue;
 
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
-                        dbgs() << getDebugIndent(' ')
-                               << "Creating void-returning variant of "
-                               << Fun->getName() << "\n");
+        LOG_VERBOSE_EXTRA("Creating void-returning variant of "
+                          << Fun->getName() << "\n");
 
         // Create a clone of the function.
         // Note: this is needed because the arguments of the original function
@@ -166,12 +164,10 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
                 CallInst *CI_New = CallInst::Create(Fun_New, Args_AR, "", CI);
                 copyCallInstProperties(CI, CI_New);
 
-                DEBUG_WITH_TYPE(
-                        DEBUG_SIMPLL_VERBOSE_EXTRA, increaseDebugIndentLevel();
-                        dbgs()
-                        << getDebugIndent() << "Replacing :" << *CI << "\n"
-                        << getDebugIndent() << "     with :" << *CI_New << "\n";
-                        decreaseDebugIndentLevel());
+                LOG_INDENT();
+                LOG_VERBOSE_EXTRA("Replacing :" << *CI << "\n");
+                LOG_VERBOSE_EXTRA("     with :" << *CI_New << "\n");
+                LOG_UNINDENT();
                 // Erase the old instruction
                 CI->eraseFromParent();
             }
@@ -184,6 +180,6 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
         Fun->eraseFromParent();
     }
 
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
+    LOG_UNINDENT();
     return PreservedAnalyses();
 }

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -74,7 +74,7 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
             // Nothing to replace.
             continue;
 
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                         dbgs() << getDebugIndent(' ')
                                << "Creating void-returning variant of "
                                << Fun->getName() << "\n");
@@ -167,7 +167,7 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
                 copyCallInstProperties(CI, CI_New);
 
                 DEBUG_WITH_TYPE(
-                        DEBUG_SIMPLL_VERBOSE, increaseDebugIndentLevel();
+                        DEBUG_SIMPLL_VERBOSE_EXTRA, increaseDebugIndentLevel();
                         dbgs()
                         << getDebugIndent() << "Replacing :" << *CI << "\n"
                         << getDebugIndent() << "     with :" << *CI_New << "\n";

--- a/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
+++ b/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
@@ -16,6 +16,7 @@
 
 #include "SeparateCallsToBitcastPass.h"
 
+#include "Logger.h"
 #include "Utils.h"
 #include <Config.h>
 #include <llvm/IR/Instructions.h>
@@ -109,10 +110,9 @@ PreservedAnalyses
 
                     // Replace the old call instruction with the last generated
                     // instruction.
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
-                                    dbgs() << "Replacing :" << *Call
-                                           << "\n   with :" << *replacementValue
-                                           << "\n");
+                    LOG_VERBOSE_EXTRA_NO_INDENT("Replacing :"
+                                                << *Call << "\n   with :"
+                                                << *replacementValue << "\n");
                     Call->replaceAllUsesWith(replacementValue);
                     toRemove.push_back(Call);
                 }

--- a/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
+++ b/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
@@ -109,7 +109,7 @@ PreservedAnalyses
 
                     // Replace the old call instruction with the last generated
                     // instruction.
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
+                    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                                     dbgs() << "Replacing :" << *Call
                                            << "\n   with :" << *replacementValue
                                            << "\n");

--- a/diffkemp/simpll/passes/VarDependencySlicer.cpp
+++ b/diffkemp/simpll/passes/VarDependencySlicer.cpp
@@ -41,7 +41,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
     IncludedBasicBlocks.clear();
     IncludedParams.clear();
 
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                     dbgs() << "Function: " << Fun.getName().str() << "\n");
 
     // First phase - determine which instructions are dependent on the parameter
@@ -69,7 +69,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
 
             if (dependent) {
                 addToDependent(&Instr);
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, {
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA, {
                     dbgs() << "Dependent: ";
                     Instr.print(dbgs());
                 });
@@ -89,7 +89,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
 
     // Second phase - determine which additional instructions we need to
     // produce a valid CFG
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, dbgs() << "Second phase\n");
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA, dbgs() << "Second phase\n");
     // Recursively add all instruction operands to included
     for (auto &Inst : DependentInstrs) {
         if (isa<PHINode>(Inst))
@@ -173,7 +173,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
         // Collect and clear all instruction that can be removed
         for (auto &Inst : BB) {
             if (!isIncluded(&Inst) && !Inst.isTerminator()) {
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                                 { dbgs() << "Clearing " << Inst << "\n"; });
                 Inst.replaceAllUsesWith(UndefValue::get(Inst.getType()));
                 toRemove.push_back(&Inst);
@@ -190,7 +190,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
     // to return void
     if (RetBB && !RetBB->empty() && !isIncluded(RetBB->getTerminator())
         && !Fun.getReturnType()->isVoidTy()) {
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                         dbgs() << "Changing return type of " << Fun.getName()
                                << " to void.\n");
         changeToVoid(Fun);
@@ -230,7 +230,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
     //       in a newer version of LLVM.
     deleteUnreachableBlocks(Fun);
 
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, {
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA, {
         dbgs() << "Function " << Fun.getName().str() << " after cleanup:\n";
         Fun.print(dbgs());
         dbgs() << "\n";
@@ -281,7 +281,7 @@ void VarDependencySlicer::addAllInstrs(
         IncludedBasicBlocks.insert(BB);
         for (auto &Instr : *BB) {
             DependentInstrs.insert(&Instr);
-            DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, {
+            DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA, {
                 dbgs() << "Dependent: ";
                 Instr.print(dbgs());
             });
@@ -342,7 +342,7 @@ bool VarDependencySlicer::addAllOpsToIncluded(const Instruction *Inst) {
     for (auto &Op : Inst->operands()) {
         if (auto OpInst = dyn_cast<Instruction>(&Op)) {
             if (addToIncluded(OpInst)) {
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, {
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA, {
                     dbgs() << "Included: ";
                     OpInst->print(dbgs());
                 });


### PR DESCRIPTION
Adds debug output, allowing to log comparisons in DifferentialFunctionComparator. The logger takes into account the hierarchy of comparisons, logging only messages of comparisons that lead to failure on instruction comparisons or those that are forced to log using higher debug level option. 